### PR TITLE
Ajout de la coloration des logs avec colorama

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -1,3 +1,7 @@
+from colorama import Fore, Style, init
+
+init()  # Initialise Colorama
+
 def main():
     counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
     with open("log.txt", "r") as file:
@@ -5,6 +9,12 @@ def main():
             for key in counts:
                 if key in line:
                     counts[key] += 1
+                    if key == "ERROR":
+                        print(Fore.RED + line.strip() + Style.RESET_ALL)
+                    elif key == "WARNING":
+                        print(Fore.YELLOW + line.strip() + Style.RESET_ALL)
+                    elif key == "INFO":
+                        print(Fore.GREEN + line.strip() + Style.RESET_ALL)
 
     with open("rapport.txt", "w") as report:
         for key, value in counts.items():


### PR DESCRIPTION
Cette Pull Request propose les améliorations suivantes sur le projet `log-analyzer` :

- Affichage des lignes de logs colorées dans le terminal selon le niveau (`INFO`, `WARNING`, `ERROR`) grâce à la bibliothèque `colorama`.
- Meilleure lisibilité lors de l'exécution du script `analyze.py`.
- Conservation du fichier `rapport.txt` inchangée (statistiques des logs).

Ces modifications ont été réalisées dans la branche `dev`.  
Une revue est demandée avant fusion dans la branche `main`.
